### PR TITLE
Fix security issues

### DIFF
--- a/backend/import_eeg_data.py
+++ b/backend/import_eeg_data.py
@@ -4,6 +4,7 @@ import csv
 import glob
 import time
 import sys
+import os
 
 # --- Configuration ---
 BASE_URL = "http://localhost:8080/api"
@@ -56,11 +57,15 @@ def import_data(token):
         print(f"Finished processing {file_path}")
 
 if __name__ == "__main__":
-    if len(sys.argv) < 2:
+    jwt_token = os.environ.get("JWT_TOKEN")
+    if len(sys.argv) >= 2:
+        jwt_token = sys.argv[1]
+
+    if not jwt_token:
         print("Usage: python import_eeg_data.py <your_jwt_token_here>")
+        print("Or set the JWT_TOKEN environment variable with a valid token.")
         print("You can get a token by registering and then logging in via the API.")
         print("Example login with cURL (replace with your user):")
         print('curl -X POST http://localhost:8080/api/login -H "Content-Type: application/json" -d \'{"username":"testuser", "password":"password"}\'')
     else:
-        jwt_token = sys.argv[1]
         import_data(jwt_token)

--- a/backend/send_eeg_data.py
+++ b/backend/send_eeg_data.py
@@ -2,11 +2,13 @@ import requests
 import json
 import random
 import time
+import os
 
 # --- Configuration ---
 BASE_URL = "http://localhost:8080/api"
-# IMPORTANT: Replace with a valid JWT token obtained from the /api/login endpoint
-JWT_TOKEN = "your_jwt_token_here"
+# IMPORTANT: Set JWT_TOKEN environment variable with a valid token obtained from the /api/login endpoint
+
+JWT_TOKEN = os.environ.get("JWT_TOKEN", "")
 
 def generate_eeg_data():
     """Generates a dictionary with random float values for 19 channels."""
@@ -40,8 +42,8 @@ def send_data(token):
         print("Please ensure the backend server is running.")
 
 if __name__ == "__main__":
-    if JWT_TOKEN == "your_jwt_token_here":
-        print("Please update the JWT_TOKEN variable in this script with a valid token.")
+    if not JWT_TOKEN:
+        print("Please set the JWT_TOKEN environment variable with a valid token.")
         print("You can get a token by registering and then logging in via the API.")
         print("Example login with cURL (replace with your user):")
         print('curl -X POST http://localhost:8080/api/login -H "Content-Type: application/json" -d \'{"username":"testuser", "password":"password"}\'')


### PR DESCRIPTION
## Summary
- load JWT secret from `JWT_SECRET` environment variable
- sanitize uploaded filenames to avoid path traversal
- restrict prediction and EEG import paths to the uploads directory
- read JWT token for data sender from `JWT_TOKEN` environment variable
- allow import script to use JWT token from environment

## Testing
- `go vet ./...`
- `go build ./...`
- `python -m py_compile backend/send_eeg_data.py backend/import_eeg_data.py backend/test_api.py Model/simple_preprocess.py Model/train_with_preprocessed_data.py Model/predict_with_model.py Model/verify_compatibility.py Model/normalize_data.py`


------
https://chatgpt.com/codex/tasks/task_e_6873647418e8832c99b07a10ba703e6e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scripts now support obtaining JWT tokens from the JWT_TOKEN environment variable, with updated usage instructions for users.

* **Bug Fixes**
  * Improved security for file uploads and data imports by sanitizing and validating file paths, ensuring all file operations are confined to the uploads directory.
  * The backend now requires the JWT secret key to be set via the JWT_SECRET environment variable, preventing insecure defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->